### PR TITLE
fix: correct sftp env var error message

### DIFF
--- a/sftp-upload.sh
+++ b/sftp-upload.sh
@@ -4,7 +4,7 @@
 
 # Check required environment variables
 if [[ -z "$SFTP_USERNAME" || -z "$SFTP_PASSWORD" || -z "$SFTP_SERVER" || -z "$REMOTE_FOLDER" ]]; then
-  echo "Error: WEBHOOK_UUID, SFTP_USERNAME, SFTP_PASSWORD, and SFTP_SERVER environment variables must be set."
+  echo "Error: SFTP_USERNAME, SFTP_PASSWORD, SFTP_SERVER, and REMOTE_FOLDER environment variables must be set."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- fix sftp upload script error message to list correct required variables

## Testing
- `bash -n sftp-upload.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aaf66a482483308ea136ae4e7d407b