### PR TITLE
Add reply-to configuration for welcome email

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ This project provides a Telegram bot that integrates with the [Webling](https://
     ];
     ```
 
+    To specify a Reply-To address for outgoing emails, set `SMTP_REPLYTO_EMAIL`
+    and `SMTP_REPLYTO_NAME` in your configuration. Optional CC recipients can be
+    defined via `SMTP_CC_EMAIL` and `SMTP_CC_NAME`.
+
 4. **Set Up the Webhook**
 
     Deploy `telegram-webhook.php` to your HTTPS-enabled web server and set the Telegram webhook to point to it:

--- a/webhooks/telegram-webhook.php
+++ b/webhooks/telegram-webhook.php
@@ -270,6 +270,11 @@ function sendMemberMail($config, string $id) {
         if ($cc_email !== null && $cc_name !== null) {
             $mail->addCC($cc_email, $cc_name);
         }
+        $reply_email = $config['SMTP_REPLYTO_EMAIL'] ?? null;
+        $reply_name  = $config['SMTP_REPLYTO_NAME'] ?? '';
+        if ($reply_email !== null) {
+            $mail->addReplyTo($reply_email, $reply_name);
+        }
         $mail->Encoding = 'base64';
         $mail->Timeout  = 10;
         $mail->isHTML(false);


### PR DESCRIPTION
## Summary
- allow setting a Reply-To address for welcome emails via `SMTP_REPLYTO_EMAIL` and `SMTP_REPLYTO_NAME`
- document Reply-To and CC configuration options in README

## Testing
- `php -l webhooks/telegram-webhook.php`

------
https://chatgpt.com/codex/tasks/task_e_68ab414bf1388330aa229c5192d75cfd