### PR TITLE
Add SMTP configuration test tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ This project provides a Telegram bot that integrates with the [Webling](https://
     and `SMTP_REPLYTO_NAME` in your configuration. Optional CC recipients can be
     defined via `SMTP_CC_EMAIL` and `SMTP_CC_NAME`.
 
+    To verify your SMTP configuration, you can send a test email:
+
+    ```bash
+    php test-smtp.php you@example.com
+    ```
+
 4. **Set Up the Webhook**
 
     Deploy `telegram-webhook.php` to your HTTPS-enabled web server and set the Telegram webhook to point to it:

--- a/test-smtp.php
+++ b/test-smtp.php
@@ -1,0 +1,54 @@
+<?php
+require __DIR__.'/webhooks/phpmailer/src/Exception.php';
+require __DIR__.'/webhooks/phpmailer/src/PHPMailer.php';
+require __DIR__.'/webhooks/phpmailer/src/SMTP.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+$config = include __DIR__.'/webhooks/wh_config/config.php';
+
+$to = $argv[1] ?? null;
+if ($to === null) {
+    fwrite(STDERR, "Usage: php test-smtp.php <recipient-email>\n");
+    exit(1);
+}
+
+$smtpHost = $config['SMTP_HOST'] ?? null;
+$smtpPort = $config['SMTP_PORT'] ?? null;
+$smtpUser = $config['SMTP_USER'] ?? null;
+$smtpPass = $config['SMTP_PASS'] ?? null;
+$smtpFrom = $config['SMTP_FROM'] ?? null;
+
+if (in_array(null, [$smtpHost, $smtpPort, $smtpUser, $smtpPass, $smtpFrom], true)) {
+    fwrite(STDERR, "SMTP configuration incomplete.\n");
+    exit(1);
+}
+
+$mail = new PHPMailer(true);
+
+try {
+    $mail->isSMTP();
+    $mail->Host       = $smtpHost;
+    $mail->Port       = $smtpPort;
+    $mail->SMTPAuth   = true;
+    $mail->Username   = $smtpUser;
+    $mail->Password   = $smtpPass;
+    $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+    $mail->setFrom($smtpFrom, 'SMTP Test');
+
+    if (!$mail->smtpConnect()) {
+        throw new Exception('Connection to SMTP server failed: ' . $mail->ErrorInfo);
+    }
+
+    $mail->addAddress($to);
+    $mail->Subject = 'SMTP Test Message';
+    $mail->Body    = 'This is a test email confirming your SMTP settings work.';
+
+    $mail->send();
+    fwrite(STDOUT, "Test email sent to {$to}.\n");
+    $mail->smtpClose();
+} catch (Exception $e) {
+    fwrite(STDERR, 'Mailer Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add CLI script to verify SMTP configuration and send a test message
- document how to run the SMTP test script

## Testing
- `php -l test-smtp.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab6b9044288330beae6be75351e31a